### PR TITLE
Allow passing custom settings using ReactGA.set()

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -7,6 +7,12 @@ import ReactGA from 'react-ga';
 addons.register('storybook/google-analytics', (api) => {
   ReactGA.initialize(globalWindow.STORYBOOK_GA_ID, globalWindow.STORYBOOK_REACT_GA_OPTIONS);
 
+  if (window.STORYBOOK_GA_OPTIONS && 'set' in window.STORYBOOK_GA_OPTIONS) {
+    // Sets a single field and value pair or a group of field/value pairs on a tracker object.
+    // @see https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#set
+    ReactGA.set(window.STORYBOOK_GA_OPTIONS.set);
+  }
+
   api.on(STORY_CHANGED, () => {
     const { path } = api.getUrlState();
     ReactGA.pageview(path);


### PR DESCRIPTION
Passing custom dimensions or settings can be useful when segmenting dev audiences, for example:

```js
window.STORYBOOK_GA_OPTIONS = {
  set: {
    appName: 'design-system',
    isUsingCloudEnvironment: true,
  },
};
```

## What I did

Introduced a new `STORYBOOK_GA_OPTIONS` object, where a `set` object can be passed, using this format: https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#set

The README and stories should be updated, but first I'd like to get feedback on this API.
