### PR TITLE
Add support for Google Analytics v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/addon-google-analytics",
-  "version": "6.3.0-next.0",
+  "version": "6.5.16",
   "description": "Storybook addon for google analytics",
   "keywords": [
     "storybook-addons",
@@ -30,7 +30,7 @@
     "release": "npm run build && auto shipit"
   },
   "dependencies": {
-    "react-ga": "^2.7.0"
+    "react-ga4": "^2.0.0" 
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -38,7 +38,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.13.0",
-    "@storybook/react": "^6.1.14",
+    "@storybook/react": "^6.5.16",
     "auto": "^10.3.0",
     "babel-loader": "^8.1.0",
     "chalk": "^2.4.2",
@@ -49,13 +49,13 @@
     "typescript": "^4.2.4"
   },
   "peerDependencies": {
-    "@storybook/addons": "^6.1.14",
-    "@storybook/api": "^6.1.14",
-    "@storybook/components": "^6.1.14",
-    "@storybook/core-events": "^6.1.14",
-    "@storybook/theming": "^6.1.14",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "@storybook/addons": "^6.5.16",
+    "@storybook/api": "^6.5.16",
+    "@storybook/components": "^6.5.16",
+    "@storybook/core-events": "^6.5.16",
+    "@storybook/theming": "^6.5.16",
+    "react": "16.8.0 - 18",
+    "react-dom": "16.8.0 - 18"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/src/register.ts
+++ b/src/register.ts
@@ -2,7 +2,13 @@ import { window as globalWindow } from 'global';
 import { addons } from '@storybook/addons';
 import { STORY_CHANGED, STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
 
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
+
+declare global {
+  interface Window {
+    STORYBOOK_GA_OPTIONS: object
+  }
+}
 
 addons.register('storybook/google-analytics', (api) => {
   ReactGA.initialize(globalWindow.STORYBOOK_GA_ID, globalWindow.STORYBOOK_REACT_GA_OPTIONS);
@@ -15,16 +21,16 @@ addons.register('storybook/google-analytics', (api) => {
 
   api.on(STORY_CHANGED, () => {
     const { path } = api.getUrlState();
-    ReactGA.pageview(path);
+    ReactGA.send({ hitType: "pageview", page: path });
   });
   api.on(STORY_ERRORED, ({ description }: { description: string }) => {
-    ReactGA.exception({
+    ReactGA.event("exception", {
       description,
       fatal: true,
     });
   });
   api.on(STORY_MISSING, (id: string) => {
-    ReactGA.exception({
+    ReactGA.event("exception", {
       description: `attempted to render ${id}, but it is missing`,
       fatal: false,
     });


### PR DESCRIPTION
Google Universal Analytics is being deprecated later this year and Google Analytics 4 is the currently supported version for stats tracking.

This PR adds support for GA4 by updating the underlying ReactGA library and some associated methods for tracking events in GA.

This targets Storybook v6.x. I will submit a different PR for v7.

I tested this with the local install of SB included in the repo and worked properly in my GA project. I suggest performing the same test by updating the tracking ID in `./storybook/manager.js`.